### PR TITLE
Revert "add vimNox to nix setup"

### DIFF
--- a/nixpkgs/config.nix
+++ b/nixpkgs/config.nix
@@ -24,7 +24,6 @@
         tmux
         tree
         unzip
-        vimNox
         watch
         wget
         zsh

--- a/scripts/brew_setup.sh
+++ b/scripts/brew_setup.sh
@@ -18,6 +18,7 @@ brew install \
     gnome-common \
     grip \
     llvm \
-    neovim
+    neovim \
+    vim
 
 brew cleanup


### PR DESCRIPTION
This reverts commit ac419b692972ce4a7007dc6dcc5f140ae7cf103b.

This version of vim is waayyy too old for my plugins. Need to come up with a better solution for getting python into vim.